### PR TITLE
Update for sprockets 4 and sassc-rails

### DIFF
--- a/lib/sprockets/svgo/sass_functions.rb
+++ b/lib/sprockets/svgo/sass_functions.rb
@@ -1,11 +1,20 @@
 module Sprockets
-  module SassProcessor::Functions
+  module SVGO::SassFunctions
     def svgo_data_uri(path, options = {})
-      options = options.transform_values(&:value).symbolize_keys
+      options = options.to_h.map { |k, v| [k.value.to_sym, v.value] }.to_h
+      if options[:precision]
+        options[:precision] = options[:precision].to_i
+      end
       url = sprockets_context.svgo_asset_data_uri(path.value, options)
-      Autoload::Sass::Script::String.new("url(" + url + ")")
+      Autoload::SassC::Script::Value::String.new("url(" + url + ")")
     end
-
-    Autoload::Sass::Script::Functions.declare :svgo_data_uri, [:path], var_kwargs: true
   end
 end
+
+if defined?(SassC::Rails)
+  # This module is used by sassc-rails, if loaded
+  SassC::Rails::SassTemplate::Functions.send :include, Sprockets::SVGO::SassFunctions
+end
+
+# This module is used by sprockets itself, if sassc-rails is not loaded
+Sprockets::SasscProcessor::Functions.send :include, Sprockets::SVGO::SassFunctions


### PR DESCRIPTION
The [Trix README](https://github.com/basecamp/trix#styling-formatted-content) recommends using a CSS class other than `trix-content` by importing Trix's stylesheet into the including project. Importing `content.scss` from Trix and continuing to use `trix/dist/trix.css` means that the `trix-content` stylesheet is still present, just unused. This can be avoided by importing the rest of Trix's stylesheets and dropping `trix/dist/trix.css`, but `icons.scss` depends on this Ruby gem to perform the SVG optimisation. A Rails project using ActionText will be using sprockets 4 and sassc, which the released version of this gem does not support. This pull request updates the gem to work in a sprockets 4 environment.

## What has changed?

The `sassc-ruby` script interface is different from `ruby-sass`, and at the current time does not seem to support keyword arguments. I've rework the function to accept an option map instead. This also requires a change in the calling syntax:

```
$icon-attach: svgo-data-uri('trix/images/attach.svg', $precision: 1);
```

should become

```
$icon-attach: svgo-data-uri('trix/images/attach.svg', ('precision': 1));
```

The method of registering custom Sass functions is also different. `Functions#declare` does not exist; instead the custom functions must be defined on specific modules provided by the processor library. This is complicated by there being two sassc processors in general use. `sprockets` provides `Sprockets::SasscProcessor` while `sassc-rails` provides `SassC::Rails::SassTemplate` overriding the processor that `sprockets` provides. Each of these processors has its own module on which custom functions are defined, so we extract the `svgo` function in to a module and include it into each.